### PR TITLE
meta: add project board and stale configs

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,1 @@
+_extends: .github

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,14 @@
+name: Add new item to project board
+
+on:
+  issues:
+    types:
+      - opened
+  pull_request_target:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+      uses: unleash/.github/.github/workflows/add-item-to-project.yml@main
+      secrets: inherit


### PR DESCRIPTION
As part of putting this project under the official Unleash umbrella, this PR suggests adds a little bit of automation that we use for maintenance purposes.

## `add-to-project.yml`

### What

This config takes care of adding all new issues and PRs to the [Unleash project board](https://github.com/orgs/Unleash/projects/8/), which we use to keep track of incoming issues and PRs.

### Why

With over 50 repos on GitHub, it's hard for us to keep track of incoming issues and PRs. This automation is here to try and make sure we don't miss any issues.

### What does this mean for you as a maintainer?

As the maintainer of this repository, we expect you to be the primary caretaker of incoming issues and PRs. However, we still find it useful to have an overview over what happens. Also, in cases where you're busy or otherwise indisposed, it also lets us step in and help out.

### Discussion points: project boards

At the moment, we try to respond to incoming issues and PRs on all our repos as soon as we see them. This is to acknowledge incoming issues and give the reporter a rough idea of what they can suggest.

- In this repo: would you as a maintainer prefer to take care of that instead? That is, should members of the general Unleash team keep an active watch and respond to things here, or would you prefer to do it yourself?

- If you do not agree with new issues and PRs being listed on the Unleash project board, then we're very happy to hear you out and have the discussion. It has worked well for us thus far, but we're always willing to reevaluate.

## `stale.yml`

This config file adds a stale bot config to this repo. By default, it just extends the basic [Unleash stale bot config](https://github.com/Unleash/.github/blob/main/.github/stale.yml), but it can be overridden if you want to.

### Protected labels

By default, the stale bot will not touch issues/prs with the labels `pinned` or `security`.

### Discussion / what does this mean for you as a maintainer?

We acknowledge that not everyone agrees with the idea of using stale bots and closing inactive issues. We have found that it works well for us internally because it's easy to forget about an issue, and stale bot gives you reminders when you do.

However, as a maintainer, this is **your** repository. **You** are ultimately in charge of how you manage issues and PRs.

As such, it's ultimately **up to you** whether you want to use a stale bot or not. You can also **override/extend** the shared config if you want to change timeouts, protected labels etc.

Let me know what you think and we can take it from there ☺️