### PR TITLE
Change groupId from net.leodb to io.getunleash to match with the groupId of the core SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The following dependency needs to be added to the springboot project pom.
 
 ```xml
 <dependency>
-    <groupId>net.leodb.unleash</groupId>
+    <groupId>io.getunleash</groupId>
     <artifactId>springboot-unleash-starter</artifactId>
     <version>Latest version here</version>
 </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,6 @@
             <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
         </license>
     </licenses>
-<!-- gh repo clone Unleash/unleash-spring-boot-starter -->
     <scm>
         <connection>scm:git:git://github.com:Unleash/unleash-spring-boot-starter.git</connection>
         <developerConnection>scm:git:ssh://github.com:Unleash/unleash-spring-boot-starter.git</developerConnection>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     </modules>
 
     <name>Unleash features starter</name>
-    <url>https://github.com/praveenpg/unleash-starter</url>
+    <url>https://github.com/Unleash/unleash-spring-boot-starter</url>
 
     <developers>
         <developer>
@@ -44,11 +44,11 @@
             <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
         </license>
     </licenses>
-
+<!-- gh repo clone Unleash/unleash-spring-boot-starter -->
     <scm>
-        <connection>scm:git:git://github.com:praveenpg/unleash-starter.git</connection>
-        <developerConnection>scm:git:ssh://github.com:praveenpg/unleash-starter.git</developerConnection>
-        <url>https://github.com/praveenpg/unleash-starter/tree/master</url>
+        <connection>scm:git:git://github.com:Unleash/unleash-spring-boot-starter.git</connection>
+        <developerConnection>scm:git:ssh://github.com:Unleash/unleash-spring-boot-starter.git</developerConnection>
+        <url>https://github.com/Unleash/unleash-spring-boot-starter/tree/master</url>
     </scm>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>net.leodb.unleash</groupId>
+    <groupId>io.getunleash</groupId>
     <artifactId>unleash-starter</artifactId>
     <packaging>pom</packaging>
     <version>1.0.0-SNAPSHOT</version>

--- a/springboot-unleash-autoconfigure/pom.xml
+++ b/springboot-unleash-autoconfigure/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>unleash-starter</artifactId>
-        <groupId>net.leodb.unleash</groupId>
+        <groupId>io.getunleash</groupId>
         <version>1.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -35,7 +35,7 @@
         </dependency>
 
         <dependency>
-            <groupId>net.leodb.unleash</groupId>
+            <groupId>io.getunleash</groupId>
             <artifactId>springboot-unleash-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/springboot-unleash-core/pom.xml
+++ b/springboot-unleash-core/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>unleash-starter</artifactId>
-        <groupId>net.leodb.unleash</groupId>
+        <groupId>io.getunleash</groupId>
         <version>1.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/springboot-unleash-starter/pom.xml
+++ b/springboot-unleash-starter/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>unleash-starter</artifactId>
-        <groupId>net.leodb.unleash</groupId>
+        <groupId>io.getunleash</groupId>
         <version>1.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -19,12 +19,12 @@
 
     <dependencies>
         <dependency>
-            <groupId>net.leodb.unleash</groupId>
+            <groupId>io.getunleash</groupId>
             <artifactId>springboot-unleash-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>net.leodb.unleash</groupId>
+            <groupId>io.getunleash</groupId>
             <artifactId>springboot-unleash-autoconfigure</artifactId>
             <version>${project.version}</version>
         </dependency>


### PR DESCRIPTION
Change groupId from net.leodb to io.getunleash to match with the groupId of the core SDK

<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->
Current groupId is `net.leodb.unleash`. This is being changed to `io.getunleash` which is the same as the groupId of the client SDK

<!-- Does it close an issue? Multiple? -->
Closes # .

<!-- (For internal contributors): Does it relate to an issue on public roadmap (https://github.com/orgs/Unleash/projects/5)? -->

<!-- Relates to roadmap item:  -->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->
README.md
pom.xml
springboot-unleash-core/pom.xml
springboot-unleash-starter/pom.xml
springboot-unleash-autoconfigure/pom.xml

## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
