### PR TITLE
Configure release flow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+name: Build and test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version:
+          - 8
+          - 11
+          - 17
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: ${matrix.version}
+      - name: Run tests
+        run: |
+          mvn clean verify -B

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.version }}
+          cache: 'maven'
       - name: Run tests
         run: |
           mvn clean verify -B

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: ${matrix.version}
+          java-version: ${{ matrix.version }}
       - name: Run tests
         run: |
           mvn clean verify -B

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -1,0 +1,32 @@
+name: Build and test
+
+on:
+  push:
+    tags:
+      - 'v*'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags') && !contains(github.event.head_commit.message, '[ci skip]')"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          gpg-private-key: ${{ GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+          cache: 'maven'
+          server-id: 'osrrh'
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_CENTRAL_TOKEN
+      - name: Release to maven central
+        run: |
+          mvn deploy
+        env:
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+

--- a/README.md
+++ b/README.md
@@ -179,3 +179,18 @@ public class FeatureDemoController {
 
 - git link to example app below:
   - https://github.com/praveenpg/unleash-starter-demo
+
+
+## Development
+
+### Releasing a new version
+
+If you have push rights to the repo, make sure there are no modifications that haven't been checked in. Then run
+```bash
+mvn release:prepare
+```
+and answer the prompts for new release version. 
+
+Once that's done, a new tag should've been created in the repo, and the [deploy release](./.github/workflows/deploy-release.yml) workflow will do the actual deploy.
+
+Then, run mvn release:clean to clean your repo for release artifacts which only clutters up the main branch. This will leave you 

--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,14 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>3.0.0-M7</version>
+                <configuration>
+                    <tagNameFormat>v@{project.version}</tagNameFormat>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
## What
This adds the option to try to deploy artifacts to maven central from tags. Reducing manual release work to be running release:prepare.

As well as adding a default build/test workflow

## Interesting things to consider
How to move to next snapshot version, when not running `mvn release:perform` locally anymore. Should be a small concern, but would be nice to have automated as well.

## Missing information
This repo does not yet have the necessary secrets for this setup to work, but I'll add them as we get closer to merging this PR.

