### PR TITLE
task: Move to Spring boot 3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,6 @@ jobs:
     strategy:
       matrix:
         version:
-          - 11
           - 17
     steps:
       - name: Checkout

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.0.1</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <groupId>io.getunleash</groupId>
+    <artifactId>spring-boot-starter-demo</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>spring-boot-starter-demo</name>
+    <description>Demo project for Spring Boot</description>
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.getunleash</groupId>
+            <artifactId>springboot-unleash-starter</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/example/src/main/java/io/getunleash/FeatureDemoController.java
+++ b/example/src/main/java/io/getunleash/FeatureDemoController.java
@@ -1,0 +1,23 @@
+package io.getunleash;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.unleash.features.annotation.Context;
+
+@RestController
+@RequestMapping("/feature")
+public class FeatureDemoController {
+    private final FeatureDemoService featureDemoService;
+    public FeatureDemoController(@Qualifier("featureOldService") final FeatureDemoService featureDemoService) {
+        this.featureDemoService = featureDemoService;
+    }
+
+    @GetMapping
+    public String feature(@RequestParam @Context(name = "name") final String name) {
+        return featureDemoService.getDemoString(name);
+    }
+
+}

--- a/example/src/main/java/io/getunleash/FeatureDemoService.java
+++ b/example/src/main/java/io/getunleash/FeatureDemoService.java
@@ -1,0 +1,8 @@
+package io.getunleash;
+
+import org.unleash.features.annotation.Toggle;
+
+public interface FeatureDemoService {
+    @Toggle(name = "feature-demo-toggle", alterBean = "featureNewService")
+    String getDemoString(String name);
+}

--- a/example/src/main/java/io/getunleash/FeatureDemoServiceNewImpl.java
+++ b/example/src/main/java/io/getunleash/FeatureDemoServiceNewImpl.java
@@ -1,0 +1,11 @@
+package io.getunleash;
+
+import org.springframework.stereotype.Service;
+
+@Service("featureNewService")
+public class FeatureDemoServiceNewImpl implements FeatureDemoService {
+    @Override
+    public String getDemoString(String name) {
+        return "New implementation";
+    }
+}

--- a/example/src/main/java/io/getunleash/FeatureDemoServiceOldImpl.java
+++ b/example/src/main/java/io/getunleash/FeatureDemoServiceOldImpl.java
@@ -1,0 +1,11 @@
+package io.getunleash;
+
+import org.springframework.stereotype.Service;
+
+@Service("featureOldService")
+public class FeatureDemoServiceOldImpl implements FeatureDemoService {
+    @Override
+    public String getDemoString(String name) {
+        return "Old implementation";
+    }
+}

--- a/example/src/main/java/io/getunleash/UnleashApplication.java
+++ b/example/src/main/java/io/getunleash/UnleashApplication.java
@@ -1,0 +1,14 @@
+package io.getunleash;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.ConfigurableApplicationContext;
+
+@SpringBootApplication
+public class UnleashApplication {
+    public static void main(String[] args) {
+        ConfigurableApplicationContext app = SpringApplication.run(UnleashApplication.class);
+        System.out.println("Configured " +app.getBeanDefinitionCount() + " beans");
+    }
+
+}

--- a/example/src/main/resources/application.yaml
+++ b/example/src/main/resources/application.yaml
@@ -1,0 +1,7 @@
+io:
+  getunleash:
+    app-name: springboot-example
+    instance-id: my-instance
+    environment: development
+    api-url: "http://localhost:4242/api"
+    api-token: "*:development.32bb8c867665ddd377edfe37c50e2dcfa1d63d83c5c8bf1393156b83"

--- a/pom.xml
+++ b/pom.xml
@@ -28,11 +28,11 @@
     </description>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring.boot.version>2.7.7</spring.boot.version>
-        <spring.version>5.3.24</spring.version>
+        <spring.boot.version>3.0.2</spring.boot.version>
+        <spring.version>6.0.4</spring.version>
         <guava.version>31.0.1-jre</guava.version>
     </properties>
 
@@ -171,7 +171,6 @@
                     </execution>
                 </executions>
             </plugin>
-
         </plugins>
     </build>
 

--- a/springboot-unleash-autoconfigure/pom.xml
+++ b/springboot-unleash-autoconfigure/pom.xml
@@ -10,8 +10,8 @@
     <artifactId>springboot-unleash-autoconfigure</artifactId>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -44,10 +44,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.0</version>
+                <version>3.10.1</version>
                 <configuration>
                     <forceJavacCompilerUse>true</forceJavacCompilerUse>
-                    <release>11</release>
+                    <release>17</release>
                 </configuration>
             </plugin>
             <plugin>
@@ -66,11 +66,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.1</version>
                 <configuration>
                     <show>private</show>
                     <nohelp>true</nohelp>
-                    <source>11</source>
+                    <source>17</source>
                 </configuration>
                 <executions>
                     <execution>

--- a/springboot-unleash-autoconfigure/src/main/java/org/unleash/features/config/UnleashAutoConfiguration.java
+++ b/springboot-unleash-autoconfigure/src/main/java/org/unleash/features/config/UnleashAutoConfiguration.java
@@ -9,11 +9,11 @@ import io.getunleash.strategy.Strategy;
 import io.getunleash.util.UnleashConfig;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 import org.unleash.features.aop.UnleashContextThreadLocal;
@@ -27,8 +27,8 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 @SuppressWarnings("SpringJavaAutowiredFieldsWarningInspection")
-@Configuration
 @EnableConfigurationProperties(UnleashProperties.class)
+@AutoConfiguration
 @ComponentScan("org.unleash.features.aop")
 public class UnleashAutoConfiguration {
     @Autowired(required = false)

--- a/springboot-unleash-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/springboot-unleash-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=org.unleash.features.config.UnleashAutoConfiguration

--- a/springboot-unleash-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/springboot-unleash-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.unleash.features.config.UnleashAutoConfiguration

--- a/springboot-unleash-core/pom.xml
+++ b/springboot-unleash-core/pom.xml
@@ -70,7 +70,7 @@
                 <version>3.10.0</version>
                 <configuration>
                     <forceJavacCompilerUse>true</forceJavacCompilerUse>
-                    <release>11</release>
+                    <release>17</release>
                 </configuration>
             </plugin>
             <plugin>
@@ -78,8 +78,8 @@
                 <artifactId>aspectj-maven-plugin</artifactId>
                 <version>1.14.0</version>
                 <configuration>
-                    <complianceLevel>16</complianceLevel>
-                    <source>16</source>
+                    <complianceLevel>17</complianceLevel>
+                    <source>17</source>
                     <showWeaveInfo>true</showWeaveInfo>
                     <encoding>${project.build.sourceEncoding}</encoding>
                     <Xlint>ignore</Xlint>
@@ -132,7 +132,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.1</version>
                 <configuration>
                     <show>private</show>
                     <nohelp>true</nohelp>

--- a/springboot-unleash-starter/pom.xml
+++ b/springboot-unleash-starter/pom.xml
@@ -10,8 +10,8 @@
     <artifactId>springboot-unleash-starter</artifactId>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -33,10 +33,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.0</version>
+                <version>3.10.1</version>
                 <configuration>
                     <forceJavacCompilerUse>true</forceJavacCompilerUse>
-                    <release>11</release>
+                    <release>17</release>
                 </configuration>
             </plugin>            <plugin>
             <groupId>org.apache.maven.plugins</groupId>
@@ -54,11 +54,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.1</version>
                 <configuration>
                     <show>private</show>
                     <nohelp>true</nohelp>
-                    <source>11</source>
+                    <source>17</source>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
### What
Spring Boot 2.7 introduced a new way of registering auto-configurators: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.7-Release-Notes#auto-configuration-registration
Spring Boot 3.0 deprecated the old way of registering auto-configuration with spring.factories.

This PR updates to use the new one, as well as including an embedded example folder and moving to java 17, since Spring Boot 3.0 requires Java 17

Related to #16 