### PR TITLE
Fix typos in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The following dependency needs to be added to the springboot project pom.
 ### Add the following to application.yaml
 ```yaml
 io:
-  getunleashed:
+  getunleash:
     app-name: <application-name>
     instance-id: <instance-id>
     environment: <environment>
@@ -29,7 +29,7 @@ io:
 ex:
 ```yaml
 io:
-  getunleashed:
+  getunleash:
     app-name: springboot-test
     instance-id: instance x
     environment: development
@@ -49,7 +49,7 @@ public UnleashContextProvider unleashContextProvider(final UnleashProperties unl
         UnleashContext.Builder builder = UnleashContext.builder();
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         if (principal instanceof User) {
-            builder.userId((((User)principal).getUsername());
+            builder.userId(((User)principal).getUsername());
         }
         
         return builder


### PR DESCRIPTION
## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->
1. documented YAML configuration cannot work, because the auto-configuration [defines](https://github.com/Unleash/unleash-spring-boot-starter/blob/main/springboot-unleash-autoconfigure/src/main/java/org/unleash/features/autoconfigure/UnleashProperties.java#L30) the prefix `io.getunleash` instead of `io.getunleashed`
2. documented code example for bean of `unleashContextProvider` does not compile, because of one opening parenthesis too much.
