### PR TITLE
feat: propagate business logic exceptions

### DIFF
--- a/springboot-unleash-core/src/main/java/org/unleash/features/aop/FeatureAdvisor.java
+++ b/springboot-unleash-core/src/main/java/org/unleash/features/aop/FeatureAdvisor.java
@@ -159,7 +159,14 @@ public class FeatureAdvisor implements MethodInterceptor {
 
             return method.invoke(alterBean, mi.getArguments());
         } catch (Exception e) {
-            throw new IllegalArgumentException(String.format("Cannot invoke method %s on bean %s", method.getName(), alterBeanName), e);
+            Throwable cause = e.getCause();
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            } else if (cause instanceof Error) {
+                throw (Error) cause;
+            } else {
+                throw new RuntimeException(cause);
+            }
         }
     }
 


### PR DESCRIPTION
This change refactors how exceptions are handled in `invokeAlterBean`. Instead of catching all exceptions and wrapping them in an `IllegalArgumentException`, we now distinguish between reflection-specific exceptions. If an `IllegalAccessException` occurs, it’s wrapped in a `RuntimeException` (since it usually indicates a configuration error). For an `InvocationTargetException`, we unwrap it and rethrow its underlying cause. This ensures that business exceptions (with their original codes, messages, and HTTP statuses) aren’t masked, so they can properly be caught and handled by our `@ControllerAdvice`.

Fixes: #39 

**Note**: I've timeboxed my efforts on this task since there isn't an established test setup for these changes. Doing so would require more setup beyond the scope of this PR.