### PR TITLE
fix(build): Jreleaser should only be run on top-level parent project

### DIFF
--- a/.github/workflows/release_jreleaser.yml
+++ b/.github/workflows/release_jreleaser.yml
@@ -45,7 +45,7 @@ jobs:
           mvn --no-transfer-progress --batch-mode -Ppublication clean deploy -DaltDeploymentRepository=local::default::file://`pwd`/target/staging-deploy
       - name: Run JReleaser
         run: |
-          mvn jreleaser:full-release
+          mvn -pl io.getunleash:unleash-starter jreleaser:full-release
         env:
           JRELEASER_PROJECT_VERSION: ${{ github.event.inputs.version }}
           JRELEASER_GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
So, since we explicitly run jreleaser:<task>, maven thinks it should run it on all projects. This PR explicitly only runs it from top level project (which will release all sub-modules).